### PR TITLE
Updated CSS Selectors for background color

### DIFF
--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
 import { Map, TileLayer, LayersControl, ScaleControl } from "react-leaflet";
 import 'leaflet/dist/leaflet.css';
-const { BaseLayer, Overlay } = LayersControl;
+import './style.css';
+const { BaseLayer } = LayersControl;
 
 export default class MapView extends Component {
   constructor(props) {

--- a/src/components/Map/style.css
+++ b/src/components/Map/style.css
@@ -1,6 +1,4 @@
-@import '../../styles/leaflet.css';
-
-Map {
+.leaflet-container {
   height: 450px;
   background-color: #AAD3DF;
 }

--- a/src/components/Navi/style.css
+++ b/src/components/Navi/style.css
@@ -1,3 +1,3 @@
-div {
+div.container {
   background-color: darkgoldenrod;
 }


### PR DESCRIPTION
Issue #1

1. Updated Map's CSS selector to change background color to light blue
2. Updated Navi's CSS selector to only select navbar so that controls
    background won't be golden

![image](https://user-images.githubusercontent.com/7341105/48457636-5646f380-e7fe-11e8-87ac-6d8e3228920e.png)
